### PR TITLE
fixing issue passing secrets from cloud build trigger to app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -17,4 +17,3 @@ runtime: nodejs10
 
 env_variables:
   NODE_ENV: production
-  GCP_PROJECT: the-quizz-world

--- a/cloudbuild/gae.yaml
+++ b/cloudbuild/gae.yaml
@@ -1,11 +1,12 @@
 steps:
-- name: 'gcr.io/cloud-builders/gcloud'
-  args: ['-i -e "s/${_GCP_PROJECT}/$GCP_PROJECT/g"',
-  'app.yaml']
-  entrypoint: sed
+- name: 'ubuntu'
+  args: ['bash', './create_env.sh']
+  env:
+  - 'PROJECT=$PROJECT_ID'
+
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ['app', 'deploy',
    '--no-promote',
    '--stop-previous-version',
-   '--project', '${_GCP_PROJECT}',
+   '--project', '${PROJECT_ID}',
    '--quiet']

--- a/create_env.sh
+++ b/create_env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Adding env variable to app.yaml
+echo "  GCP_PROJECT: ${PROJECT}" >> app.yaml


### PR DESCRIPTION
I've done some research related topic passing Secret to App Engine app.yaml file.
So currently there are couple solutions I found from various summarizations:

Import at runtime: using dotenv to load the file from another storage service (ex: Cloud Storage)
(https://medium.com/@gunar/how-to-use-environment-variables-in-gcloud-app-engine-node-js-86623b3ab0f6) This will require to set up prestart hook to package.json. Also need to maintain another service, and adding access to service account. => A bit over complicated.

Inject at build time: using CI tool to load the config file from Cloud Storage. Still this needs to maintain CS bucket, and account-services.

Create at build time: using bash/shell to create/update app.yaml. Passing env variables from CI tool. I would prefer this, and after looking at some examples, this looks simplest and easiest to maintain.

